### PR TITLE
Add `mongodb-tools` for MongoDB backup support

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -36,6 +36,7 @@ RUN apk upgrade --no-cache \
     postgresql-client \
     mariadb-client \
     curl \
+    mongodb-tools
     && rm -rf /var/cache/apk/* \
     && chmod 755 /entry.sh
 VOLUME /mnt/source


### PR DESCRIPTION
MongoDB backups are supported in Borgmatic 1.5.22 (see [borgmatic-collective/borgmatic#288](https://projects.torsion.org/borgmatic-collective/borgmatic/issues/288)).

This commit adds `mongodb-tools`, which contains the required `mongodump` and `mongorestore` commands.