### PR TITLE
Mail subject and env enhancements

### DIFF
--- a/IMAGE_ARCHITECTURE.md
+++ b/IMAGE_ARCHITECTURE.md
@@ -13,7 +13,8 @@ docker-borgmatic/
 │   ├── data
 │   │   └── borgmatic.d
 │   │       ├── config.yml             # same as in base
-│   │       └── crontab.txt            # with mailto
+│   │       ├── crontab.txt            # with mailto
+│   │       ├── mailenv.sh
 │   │       └── msmtprc.sh
 │   ├── docker-compose.yml             # image: b3vis/borgmatic:latest-msmtp, env: msmtp.env
 │   ├── Dockerfile                     # FROM b3vis/borgmatic:${VERSION}

--- a/msmtp/README.md
+++ b/msmtp/README.md
@@ -1,22 +1,33 @@
-# mail notification for Borgmatic Container 
+# E-Mail notifications for docker-borgmatic 
 
 ### Description
 
-This image adds mail notification with [msmtp](https://marlam.de/msmtp/) to the docker-bormatic.
+This image adds e-mail notifications with [msmtp](https://marlam.de/msmtp/) to
+the docker-borgmatic container.
 
 ### Usage
 
-For general usage instuctions see the [README](../base/README.md) of the base image.
+For general usage instructions see the [README](../base/README.md) of the base
+image.
 
-If you want to mail the results from cron:
-* Add your mail relay details to the [msmtp.env](msmtp.env.template) or mount your own [msmtprc](https://wiki.alpinelinux.org/wiki/Relay_email_to_gmail_(msmtp,_mailx,_sendmail) to `/etc/msmtprc`
-* Add your mail address to crontab.txt by editing the line `MAILTO=log@example.com`
-* Please note that logs will no longer end up in Docker logs when MAILTO is set.
+If you want to send the backup results from cron via mail:
+* Add your mail relay details to the [msmtp.env](msmtp.env.template) or mount
+  your own
+  [msmtprc](https://wiki.alpinelinux.org/wiki/Relay_email_to_gmail_(msmtp,_mailx,_sendmail)
+  to `/etc/msmtprc`.
+* Add your recipient mail address to `crontab.txt` by editing the line
+  `MAILTO=log@example.com`.
+* Please note that logs will no longer end up in Docker logs when `MAILTO` is
+  set.
 
 ### Environment
-Set your mail configuration in `msmtp.env`
-- Your mail relay host `MAIL_RELAY_HOST=mail.example.com`
-- Port of your mail relay `MAIL_PORT=587`
-- Username used to log in into your relay service `MAIL_USER=borgmatic_log@example.com`
-- Password for relay login   `MAIL_PASSWORD=SuperS3cretMailPw`
-- From part in your log mail `MAIL_FROM=borgmatic`
+
+Set your mail configuration in `msmtp.env`:
+
+| Key                | Description                |
+| ------------------ | -------------------------- |
+| `MAIL_RELAY_HOST`  | IP or hostname of the mail relay (SMTP server) |
+| `MAIL_PORT`        | SMTP port of the mail relay |
+| `MAIL_USER`        | Username for SMTP login |
+| `MAIL_PASSWORD`    | Password for SMTP login |
+| `MAIL_FROM`        | From address for e-mail notifications |

--- a/msmtp/README.md
+++ b/msmtp/README.md
@@ -10,15 +10,21 @@ the docker-borgmatic container.
 For general usage instructions see the [README](../base/README.md) of the base
 image.
 
-If you want to send the backup results from cron via mail:
-* Add your mail relay details to the [msmtp.env](msmtp.env.template) or mount
-  your own
-  [msmtprc](https://wiki.alpinelinux.org/wiki/Relay_email_to_gmail_(msmtp,_mailx,_sendmail)
-  to `/etc/msmtprc`.
-* Add your recipient mail address to `crontab.txt` by editing the line
-  `MAILTO=log@example.com`.
-* Please note that logs will no longer end up in Docker logs when `MAILTO` is
-  set.
+To setup e-mail notifications follow these steps:
+
+* Add your mail relay details to the [msmtp.env](msmtp.env.template). See
+  the list of environment variables below.
+* Restart the container to apply the changes.
+
+For those who update the image from `v1.1.17-1.5.23` or below, you might want to
+migrate to the new e-mail notification script that provides you proper subject
+lines and adds further possibilities to use the environment for configuration:
+
+* Remove the `MAILTO` from your `crontab.txt`.
+* Edit your `crontab.txt` to match the [upstream file](data/borgmatic.d/crontab.txt).
+* Add the [`env.sh`](data/borgmatic.d/env.sh) and
+  `run.sh`(data/borgmatic.d/run.sh).
+* Extend the environment in `msmtp.env` to contain `MAIL_TO` and `MAIL_SUBJECT`.
 
 ### Environment
 
@@ -31,3 +37,5 @@ Set your mail configuration in `msmtp.env`:
 | `MAIL_USER`        | Username for SMTP login |
 | `MAIL_PASSWORD`    | Password for SMTP login |
 | `MAIL_FROM`        | From address for e-mail notifications |
+| `MAIL_TO`          | Recipients for e-mail notifications |
+| `MAIL_SUBJECT`     | Subject line for e-mail notifications |

--- a/msmtp/data/borgmatic.d/crontab.txt
+++ b/msmtp/data/borgmatic.d/crontab.txt
@@ -2,4 +2,4 @@
 # Comma separate multiple addresses, do not use spaces or quotes
 MAILTO=log@example.com
 
-0 1 * * * PATH=$PATH:/usr/bin /usr/bin/borgmatic --stats -v 0 2>&1
+0 1 * * * PATH=$PATH:/usr/bin /etc/borgmatic.d/run.sh 2>&1

--- a/msmtp/data/borgmatic.d/crontab.txt
+++ b/msmtp/data/borgmatic.d/crontab.txt
@@ -1,5 +1,4 @@
 # Set MAILTO, to send crontab output to mail (Instead of docker logs)
 # Comma separate multiple addresses, do not use spaces or quotes
-MAILTO=log@example.com
 
 0 1 * * * PATH=$PATH:/usr/bin /etc/borgmatic.d/run.sh 2>&1

--- a/msmtp/data/borgmatic.d/env.sh
+++ b/msmtp/data/borgmatic.d/env.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+cat >/etc/mailenv << EOF
+BACKUP_COMMAND="/usr/bin/borgmatic --stats -v 0"
+MAILTO="${MAIL_TO}"
+MAILSUBJECT="${MAIL_SUBJECT}"
+
+EOF

--- a/msmtp/data/borgmatic.d/env.sh
+++ b/msmtp/data/borgmatic.d/env.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 cat >/etc/mailenv << EOF
+# THIS FILE GETS RECREATED AUTOMATICALLY ON CONTAINER STARTUP
 BACKUP_COMMAND="/usr/bin/borgmatic --stats -v 0"
 MAILTO="${MAIL_TO}"
 MAILSUBJECT="${MAIL_SUBJECT}"

--- a/msmtp/data/borgmatic.d/msmtprc.sh
+++ b/msmtp/data/borgmatic.d/msmtprc.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 cat >/etc/msmtprc << EOF
+# THIS FILE GETS RECREATED AUTOMATICALLY ON CONTAINER STARTUP
 # Set default values for all following accounts.
 defaults
 auth             on

--- a/msmtp/data/borgmatic.d/run.sh
+++ b/msmtp/data/borgmatic.d/run.sh
@@ -1,4 +1,20 @@
 #!/bin/sh
 
 source /etc/mailenv
-$BACKUP_COMMAND 2>&1
+LOGFILE="/tmp/backup_run_$(date +%s).log"
+
+set -o pipefail
+$BACKUP_COMMAND 2>&1 | tee $LOGFILE
+
+if [ $? -eq "0" ]; then
+    SUBJECT_PREFIX="=?utf-8?Q? =E2=9C=85 SUCCESS?="
+else
+    SUBJECT_PREFIX="=?utf-8?Q? =E2=9D=8C FAILED?="
+fi
+
+if [ -n "$MAILTO" ]; then
+    echo -e "Subject: $SUBJECT_PREFIX: $MAILSUBJECT\n\n$(cat $LOGFILE)\n" |
+        sendmail -t $MAILTO
+fi
+
+rm $LOGFILE

--- a/msmtp/data/borgmatic.d/run.sh
+++ b/msmtp/data/borgmatic.d/run.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+source /etc/mailenv
+$BACKUP_COMMAND 2>&1

--- a/msmtp/entry.sh
+++ b/msmtp/entry.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 /bin/sh /etc/borgmatic.d/msmtprc.sh
+/bin/sh /etc/borgmatic.d/env.sh
 
 # Import your cron file
 /usr/bin/crontab /etc/borgmatic.d/crontab.txt

--- a/msmtp/msmtp.env.template
+++ b/msmtp/msmtp.env.template
@@ -2,5 +2,7 @@
 MAIL_RELAY_HOST=mail.example.com
 MAIL_PORT=587
 MAIL_FROM=pg_backup_rsynced
+MAIL_TO=
+MAIL_SUBJECT=Borgmatic Backup
 MAIL_USER=log_mail
 MAIL_PASSWORD=


### PR DESCRIPTION
The main goal of this PR is to enhance the subject line of e-mail notifications. Currently the subject of the e-mails look like this (created by cron):

```
cron: PATH=$PATH:/usr/bin /usr/bin/borgmatic --stats -v 2 2>&1
```

With this PR, they look like this:

```
 ✅ SUCCESS: Borgmatic Example Backup
```
```
 ❌ FAILED: Borgmatic Example Backup
```

I think it's quite obvious that this makes it much easier to see if there are problems as the subject line reflects the backup return status. Especially if you have multiple notifications from different sources in your mailbox.

Apart from this it is now possible to specify the recipients of the notifications in the docker environment.

What I don't really like is the current "abuse" of the `/etc/borgmatic.d` directory for all kinds of other files. IMHO this should be used only for borgmatic config files and the rest should be stored elsewhere. Also it would be nice to have default files for the crontab, and the init/run scripts inside the container image as the average user doesn't really need to mount customized versions anymore if everything can be setup via the environment. But these are separate issues for potential future PRs.

This is currently a draft until I have done some more tests. Any comments are welcome!