### PR TITLE
fix ntfy example

### DIFF
--- a/ntfy/README.md
+++ b/ntfy/README.md
@@ -21,9 +21,9 @@ Mount your own `ntfy.yml` to `/root/.config/ntfy/ntfy.yml` to set your backends 
 ```
 hooks:
     before_backup:
-        - ntfy -b pushover -t Borgmatic send "Borgmatic: Backup Starting"
+        - 'ntfy -b pushover -t Borgmatic send "Borgmatic: Backup Starting"'
     after_backup:
-        - ntfy -b pushover -t Borgmatic send "Borgmatic: Backup Finished"
+        - 'ntfy -b pushover -t Borgmatic send "Borgmatic: Backup Finished"'
     on_error:
-        - ntfy -b pushover -t Borgmatic send "Borgmatic: Backup Error!"
+        - 'ntfy -b pushover -t Borgmatic send "Borgmatic: Backup Error!"'
 ```


### PR DESCRIPTION
fixes error in parsing configuration file: `At 'hooks.after_backup[1]': {'ntfy -b pushover -t Borgmatic send "Borgmatic': 'Backup Finished"'} is not of type 'string'`