### PR TITLE
Upgrade to borgmatic 1.6.0

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.15 as builder
 LABEL mainainer='b3vis'
 ARG BORG_VERSION=1.2.0
-ARG BORGMATIC_VERSION=1.5.24
+ARG BORGMATIC_VERSION=1.6.0
 ARG LLFUSE_VERSION=1.4.1
 RUN apk upgrade --no-cache \
     && apk add --no-cache \


### PR DESCRIPTION
 * #381: BREAKING: Greatly simplify configuration file reuse by deep merging when including common
   configuration. See the documentation for more information:
   https://torsion.org/borgmatic/docs/how-to/make-per-application-backups/#include-merging
 * #473: BREAKING: Instead of executing "before" command hooks before all borgmatic actions run (and
   "after" hooks after), execute these hooks right before/after the corresponding action. E.g.,
   "before_check" now runs immediately before the "check" action. This better supports running
   timing-sensitive tasks like pausing containers. Side effect: before/after command hooks now run
   once for each configured repository instead of once per configuration file. Additionally, the
   "repositories" interpolated variable has been changed to "repository", containing the path to the
   current repository for the hook. See the documentation for more information:
   https://torsion.org/borgmatic/docs/how-to/add-preparation-and-cleanup-steps-to-backups/
 * #513: Add mention of sudo's "secure_path" option to borgmatic installation documentation.
 * #515: Fix "borgmatic borg key ..." to pass parameters to Borg in the correct order.
 * #516: Fix handling of TERM signal to exit borgmatic, not just forward the signal to Borg.
 * #517: Fix borgmatic exit code (so it's zero) when initial Borg calls fail but later retries
   succeed.
 * Change Healthchecks logs truncation size from 10k bytes to 100k bytes, corresponding to that
   same change on Healthchecks.io.