### PR TITLE
Add borgmatic state volume in preparation for borgmatic 1.6.2 feature

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -39,6 +39,7 @@ RUN apk upgrade --no-cache \
 VOLUME /mnt/source
 VOLUME /mnt/borg-repository
 VOLUME /etc/borgmatic.d
+VOLUME /root/.borgmatic
 VOLUME /root/.config/borg
 VOLUME /root/.ssh
 VOLUME /root/.cache/borg

--- a/base/docker-compose.yml
+++ b/base/docker-compose.yml
@@ -4,12 +4,13 @@ services:
     image: b3vis/borgmatic
     container_name: borgmatic
     volumes:
-      - ${VOLUME_SOURCE}:/mnt/source:ro           # backup source
-      - ${VOLUME_TARGET}:/mnt/borg-repository     # backup target
-      - ${VOLUME_ETC_BORGMATIC}:/etc/borgmatic.d/ # borgmatic config file(s) + crontab.txt
-      - ${VOLUME_BORG_CONFIG}:/root/.config/borg  # config and keyfiles
-      - ${VOLUME_SSH}:/root/.ssh                  # ssh key for remote repositories
-      - ${VOLUME_BORG_CACHE}:/root/.cache/borg    # checksums used for deduplication
+      - ${VOLUME_SOURCE}:/mnt/source:ro            # backup source
+      - ${VOLUME_TARGET}:/mnt/borg-repository      # backup target
+      - ${VOLUME_ETC_BORGMATIC}:/etc/borgmatic.d/  # borgmatic config file(s) + crontab.txt
+      - ${VOLUME_BORGMATIC_STATE}:/root/.borgmatic # borgmatic state files
+      - ${VOLUME_BORG_CONFIG}:/root/.config/borg   # config and keyfiles
+      - ${VOLUME_SSH}:/root/.ssh                   # ssh key for remote repositories
+      - ${VOLUME_BORG_CACHE}:/root/.cache/borg     # checksums used for deduplication
     environment:
       - TZ=${TZ}
       - BORG_PASSPHRASE=${BORG_PASSPHRASE}

--- a/msmtp/docker-compose.yml
+++ b/msmtp/docker-compose.yml
@@ -5,12 +5,13 @@ services:
     env_file: msmtp.env
     container_name: borgmatic
     volumes:
-      - ${VOLUME_SOURCE}:/mnt/source:ro           # backup source
-      - ${VOLUME_TARGET}:/mnt/borg-repository     # backup target
-      - ${VOLUME_ETC_BORGMATIC}:/etc/borgmatic.d/ # borgmatic config file(s) + crontab.txt
-      - ${VOLUME_BORG_CONFIG}:/root/.config/borg  # config and keyfiles
-      - ${VOLUME_SSH}:/root/.ssh                  # ssh key for remote repositories
-      - ${VOLUME_BORG_CACHE}:/root/.cache/borg    # checksums used for deduplication
+      - ${VOLUME_SOURCE}:/mnt/source:ro            # backup source
+      - ${VOLUME_TARGET}:/mnt/borg-repository      # backup target
+      - ${VOLUME_ETC_BORGMATIC}:/etc/borgmatic.d/  # borgmatic config file(s) + crontab.txt
+      - ${VOLUME_BORGMATIC_STATE}:/root/.borgmatic # borgmatic state files
+      - ${VOLUME_BORG_CONFIG}:/root/.config/borg   # config and keyfiles
+      - ${VOLUME_SSH}:/root/.ssh                   # ssh key for remote repositories
+      - ${VOLUME_BORG_CACHE}:/root/.cache/borg     # checksums used for deduplication
     environment:
       - TZ=${TZ}
       - BORG_PASSPHRASE=${BORG_PASSPHRASE}

--- a/ntfy/docker-compose.yml
+++ b/ntfy/docker-compose.yml
@@ -4,13 +4,14 @@ services:
     image: b3vis/borgmatic:ntfy
     container_name: borgmatic
     volumes:
-      - ${VOLUME_SOURCE}:/mnt/source:ro           # backup source
-      - ${VOLUME_TARGET}:/mnt/borg-repository     # backup target
-      - ${VOLUME_ETC_BORGMATIC}:/etc/borgmatic.d/ # borgmatic config file(s) + crontab.txt
-      - ${VOLUME_BORG_CONFIG}:/root/.config/borg  # config and keyfiles
-      - ${VOLUME_SSH}:/root/.ssh                  # ssh key for remote repositories
-      - ${VOLUME_BORG_CACHE}:/root/.cache/borg    # checksums used for deduplication
-      - ${VOLUME_NTFY}:/root/.config/ntfy         # ntfy configuration: https://github.com/dschep/ntfy#configuring-ntfy
+      - ${VOLUME_SOURCE}:/mnt/source:ro            # backup source
+      - ${VOLUME_TARGET}:/mnt/borg-repository      # backup target
+      - ${VOLUME_ETC_BORGMATIC}:/etc/borgmatic.d/  # borgmatic config file(s) + crontab.txt
+      - ${VOLUME_BORGMATIC_STATE}:/root/.borgmatic # borgmatic state files
+      - ${VOLUME_BORG_CONFIG}:/root/.config/borg   # config and keyfiles
+      - ${VOLUME_SSH}:/root/.ssh                   # ssh key for remote repositories
+      - ${VOLUME_BORG_CACHE}:/root/.cache/borg     # checksums used for deduplication
+      - ${VOLUME_NTFY}:/root/.config/ntfy          # ntfy configuration: https://github.com/dschep/ntfy#configuring-ntfy
     environment:
       - TZ=${TZ}
       - BORG_PASSPHRASE=${BORG_PASSPHRASE}


### PR DESCRIPTION
In borgmatic 1.6.2, there will be a new feature for configuring check frequency that will rely on saving state in `~/.borgmatic`. (See https://projects.torsion.org/borgmatic-collective/borgmatic/issues/523 for the gory details.)

This PR is therefore an update to the Docker volumes in this project's container, adding back `/root/.borgmatic` as a volume so that borgmatic's saved state is persisted across container runs. Without this change, borgmatic would "forget" that it had done particular consistency checks and run them more frequently than is configured—not the worst thing in the world, but not ideal.

Testing done: None! (Please let me know if you'd like me to do something in particular.)