### PR TITLE
Bash completion

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -35,6 +35,8 @@ RUN apk upgrade --no-cache \
     curl \
     findmnt \
     logrotate \
+    bash \
+    bash-completion \
     && rm -rf /var/cache/apk/*
 VOLUME /mnt/source
 VOLUME /mnt/borg-repository
@@ -49,4 +51,6 @@ COPY --from=builder /usr/bin/borgmatic /usr/bin/
 COPY --from=builder /usr/bin/generate-borgmatic-config /usr/bin/
 COPY --from=builder /usr/bin/upgrade-borgmatic-config /usr/bin/
 COPY --from=builder /usr/bin/validate-borgmatic-config /usr/bin/
+RUN borgmatic --bash-completion > /usr/share/bash-completion/completions/borgmatic
+RUN echo "source /etc/profile.d/bash_completion.sh" > /root/.bashrc
 CMD ["/entry.sh"]

--- a/base/README.md
+++ b/base/README.md
@@ -86,7 +86,7 @@ is needed for *SELinux*, while `apparmor:unconfined` is needed for *AppArmor*.
 To init the repo with encryption, run:
 ```
 docker exec borgmatic \
-sh -c "borgmatic --init --encryption repokey-blake2"
+bash -c "borgmatic --init --encryption repokey-blake2"
 ```
 
 ### Layout
@@ -100,7 +100,7 @@ Where you need to create crontab.txt and your borgmatic config.yml
 - To generate an example borgmatic configuration, run:
 ```
 docker exec borgmatic \
-sh -c "cd && generate-borgmatic-config -d /etc/borgmatic.d/config.yaml"
+bash -c "cd && generate-borgmatic-config -d /etc/borgmatic.d/config.yaml"
 ```
 - crontab.txt example: In this file set the time you wish for your backups to take place default is
   1am every day. In here you can add any other tasks you want ran
@@ -136,3 +136,13 @@ A non-volatile place to store the borg chunk cache.
     4. Restore your files
     5. Finally unmount and exit: `borg umount <mount_point> && exit`.
   - In case Borg fails to create/acquire a lock: `borg break-lock /mnt/repository`
+
+### Example interactive command
+
+If you ever need to run borgmatic manually, for instance to view or recover files, run:
+
+```
+docker exec -it borgmatic bash
+```
+
+Then you can run `borgmatic` directly within that shell.


### PR DESCRIPTION
borgmatic 1.6.2 will include support for Bash completion (tab completion), and this PR adds support for it to the Docker image. The idea is that you can `exec` into the image (e.g. when viewing or recovering files) and tab-complete your borgmatic command-line.

It's possible that you think Bash doesn't belong in this Docker image. If that's the case, please just let me know and I'll withdraw the PR! But I wanted to send this over in case you wanted it.

NOTE: Please do not land this until after borgmatic 1.6.2 is released! It won't work until then.

Testing done: Built the image (with my local requirements.txt hacked to install borgmatic from master) and ran `docker exec -it borgmatic bash`. Then I started typing `borgmatic ` and hit tab twice to confirm completion worked as expected.