### PR TITLE
Make script files executable

### DIFF
--- a/msmtp/Dockerfile
+++ b/msmtp/Dockerfile
@@ -2,6 +2,7 @@ FROM b3vis/borgmatic:latest
 LABEL mainainer='b3vis'
 COPY entry.sh /entry.sh
 COPY data/scripts /scripts
+RUN chmod +x /scripts/*
 COPY data/borgmatic.d /etc/borgmatic.d
 RUN apk upgrade --no-cache \
     && apk add --no-cache \

--- a/msmtp/data/borgmatic.d/crontab.txt
+++ b/msmtp/data/borgmatic.d/crontab.txt
@@ -1,4 +1,4 @@
 # Set MAILTO, to send crontab output to mail (Instead of docker logs)
 # Comma separate multiple addresses, do not use spaces or quotes
 
-0 1 * * * PATH=$PATH:/usr/bin /scripts/run.sh 2>&1
+0 1 * * * /scripts/run.sh 2>&1


### PR DESCRIPTION
Hello,

As part of my previous pull request (#133), I forgot to make script files executables right from the Dockerfile. `run.sh` would not run from `crontab.txt` without this modification.

Yann