### PR TITLE
Remove redundant msmtp migration instructions

### DIFF
--- a/msmtp/README.md
+++ b/msmtp/README.md
@@ -12,7 +12,7 @@ image.
 
 To setup e-mail notifications follow these steps:
 
-* Add your mail relay details to the [msmtp.env](data/borgmatic.d/msmtp.env.template) and place it in the borgmatic.d directory. See
+* Add your mail relay details to the [`msmtp.env`](data/borgmatic.d/msmtp.env.template) and place it in the borgmatic.d directory. See
   the list of environment variables below.
 * Restart the container to apply the changes.
 
@@ -22,11 +22,11 @@ lines and adds further possibilities to use the environment for configuration:
 
 * Remove the `MAILTO` from your `crontab.txt`.
 * Edit your `crontab.txt` to match the [upstream file](data/borgmatic.d/crontab.txt).
-* Extend the environment in `msmtp.env` to contain `MAIL_TO` and `MAIL_SUBJECT`.
+* Extend the environment in [`msmtp.env`](data/borgmatic.d/msmtp.env.template) to contain `MAIL_TO` and `MAIL_SUBJECT`.
 
 ### Environment
 
-Set your mail configuration in `msmtp.env`:
+Set your mail configuration in [`msmtp.env`](data/borgmatic.d/msmtp.env.template):
 
 | Key                | Description                |
 | ------------------ | -------------------------- |

--- a/msmtp/README.md
+++ b/msmtp/README.md
@@ -22,8 +22,6 @@ lines and adds further possibilities to use the environment for configuration:
 
 * Remove the `MAILTO` from your `crontab.txt`.
 * Edit your `crontab.txt` to match the [upstream file](data/borgmatic.d/crontab.txt).
-* Add the [`env.sh`](data/borgmatic.d/env.sh) and
-  `run.sh`(data/borgmatic.d/run.sh).
 * Extend the environment in `msmtp.env` to contain `MAIL_TO` and `MAIL_SUBJECT`.
 
 ### Environment


### PR DESCRIPTION
- Removes migration instructions that are redundant due to the *.sh scripts being moved out of `borgmatic.d` and into `scripts`.
- Added links to `msmtp.env` file and adjusted formatting slightly for consistency.
