### PR TITLE
Optimising Dockerfile

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,35 +1,5 @@
-FROM alpine:3.16.2 as builder
-LABEL mainainer='b3vis'
-COPY requirements.txt /requirements.txt
-# mostly taken from https://github.com/borgbackup/borg/blob/1.1.15/Vagrantfile#L10-L26
-RUN apk update && apk add --update --no-cache \
-    alpine-sdk \
-    linux-headers \
-    py3-pkgconfig \
-    py3-wheel \
-    py3-xxhash \
-    py3-setuptools \
-    py3-pip \
-    python3-dev \
-    openssl-dev \
-    lz4-dev \
-    acl-dev \
-    fuse-dev \
-    attr-dev \
-    zlib-dev \
-    bzip2-dev \
-    ncurses-dev \
-    readline-dev \
-    xz-dev \
-    sqlite-dev \
-    libffi-dev \
-    && python3 -m pip install --no-cache-dir -U pip setuptools wheel
-
-RUN python3 -m pip install -v --no-cache-dir -U -r requirements.txt
-
 FROM alpine:3.16.2
 LABEL mainainer='b3vis'
-ARG PYTHON_VERSION=3.10
 VOLUME /mnt/source
 VOLUME /mnt/borg-repository
 VOLUME /root/.borgmatic
@@ -40,7 +10,6 @@ VOLUME /root/.cache/borg
 RUN apk add --update --no-cache \
     tzdata \
     sshfs \
-    python3 \
     openssl \
     fuse \
     ca-certificates \
@@ -58,18 +27,12 @@ RUN apk add --update --no-cache \
     && rm -rf \
     /var/cache/apk/* \
     /.cache
-COPY --from=builder /usr/lib/python${PYTHON_VERSION}/site-packages /usr/lib/python${PYTHON_VERSION}/
-COPY --chmod=755 --from=builder \ 
-     /usr/bin/borg \
-     /usr/bin/borgfs \
-     /usr/bin/borgmatic \
-     /usr/bin/generate-borgmatic-config \
-     /usr/bin/upgrade-borgmatic-config \
-     /usr/bin/validate-borgmatic-config \
-     /usr/bin/markdown_py \
-     /usr/bin/normalizer \
-     /usr/bin/apprise \
-     /usr/bin/
+
 COPY --chmod=755 entry.sh /entry.sh
+COPY --link requirements.txt /
+
+RUN python3 -m pip install --no-cache -Ur requirements.txt
 RUN borgmatic --bash-completion > /usr/share/bash-completion/completions/borgmatic && echo "source /etc/profile.d/bash_completion.sh" > /root/.bashrc
+
 CMD ["/entry.sh"]
+

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10.5-alpine3.16
+FROM python:3.10.6-alpine3.16
 LABEL mainainer='b3vis'
 VOLUME /mnt/source
 VOLUME /mnt/borg-repository
@@ -35,4 +35,3 @@ RUN python3 -m pip install --no-cache -Ur requirements.txt
 RUN borgmatic --bash-completion > /usr/share/bash-completion/completions/borgmatic && echo "source /etc/profile.d/bash_completion.sh" > /root/.bashrc
 
 CMD ["/entry.sh"]
-

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.16.2
+FROM python:3.10.5-alpine3.16
 LABEL mainainer='b3vis'
 VOLUME /mnt/source
 VOLUME /mnt/borg-repository


### PR DESCRIPTION
As we're creating wheels in an index, and not building inside the image, there's no need to have the build step in the Dockerfile. 

I've also changed the image to the python alpine image as we're already installing python 3.10.5, might as well get it directly from the source, and allows for easier updating/rolling back of the core python packages. 

Image build time is reduced, and size is reduced by a few MB.

Have tested with a full backup.