### PR TITLE
Crontab changes

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,6 +1,6 @@
 # syntax = docker/dockerfile:latest
 
-FROM python:3.10.6-alpine3.16
+FROM python:3.11.0-alpine3.16
 LABEL mainainer='b3vis'
 VOLUME /mnt/source
 VOLUME /mnt/borg-repository

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,3 +1,5 @@
+# syntax = docker/dockerfile:latest
+
 FROM python:3.10.6-alpine3.16
 LABEL mainainer='b3vis'
 VOLUME /mnt/source

--- a/base/data/borgmatic.d/crontab.txt
+++ b/base/data/borgmatic.d/crontab.txt
@@ -1,1 +1,0 @@
-0 1 * * * PATH=$PATH:/usr/local/bin /usr/local/bin/borgmatic --stats -v 0 2>&1

--- a/base/entry.sh
+++ b/base/entry.sh
@@ -1,17 +1,22 @@
 #!/bin/sh
 
-# Import your cron file
-/usr/bin/crontab /etc/borgmatic.d/crontab.txt
+# Generate Cron variables
+export CRON=${CRON:-"0 1 * * *"}
+export CRON_COMMAND=${CRON_COMMAND:-"borgmatic --stats -v 0 2>&1"}
 
-#Variables
+# Output cron settings to console
+echo "Cron job set as: \"$CRON $CRON_COMMAND\""
+
+# Version variables
 borgver=$(borg --version)
 borgmaticver=$(borgmatic --version)
 apprisever=$(apprise --version | grep -Eo '[0-9]+\.[0-9]+\.[0-9]+')
 
-#Software versions
+# Software versions
 echo borgmatic $borgmaticver
 echo $borgver
 echo apprise $apprisever
 
 # Start cron
+echo "$CRON $CRON_COMMAND" > /etc/crontabs/root
 /usr/sbin/crond -f -L /dev/stdout

--- a/base/entry.sh
+++ b/base/entry.sh
@@ -1,11 +1,4 @@
-#!/bin/sh
-
-# Generate Cron variables
-export CRON=${CRON:-"0 1 * * *"}
-export CRON_COMMAND=${CRON_COMMAND:-"borgmatic --stats -v 0 2>&1"}
-
-# Output cron settings to console
-echo "Cron job set as: \"$CRON $CRON_COMMAND\""
+#!/bin/bash
 
 # Version variables
 borgver=$(borg --version)
@@ -17,6 +10,36 @@ echo borgmatic $borgmaticver
 echo $borgver
 echo apprise $apprisever
 
-# Start cron
-echo "$CRON $CRON_COMMAND" > /etc/crontabs/root
-/usr/sbin/crond -f -L /dev/stdout
+# Disable cron if it's set to disabled.
+if [[ "$CRON" =~ ^(false|disabled|off)$ ]]; then
+    echo "Disabling cron, removing configuration"
+    # crontab -r # quite destructive
+    # echo -n > /etc/crontabs/root # Empty config, doesn't look as nice with "crontab -l"
+    echo "# Cron disabled" > /etc/crontabs/root
+    echo "Cron is now disabled"
+# Apply default or custom cron if $CRON is unset or set (not null):
+elif [[ -v CRON ]]; then
+    CRON="${CRON:-"0 1 * * *"}"
+    CRON_COMMAND="${CRON_COMMAND:-"borgmatic --stats -v 0 2>&1"}"
+    echo "$CRON $CRON_COMMAND" > /etc/crontabs/root
+    echo "Applying custom cron"
+# If nothing is set, revert to default behaviour
+else
+    echo "Applying crontab.txt"
+    crontab /etc/borgmatic.d/crontab.txt
+fi
+
+# Apply extra cron if it's set
+if [ -v EXTRA_CRON ]
+then
+    echo "$EXTRA_CRON" >> /etc/crontabs/root
+fi
+
+# Current crontab var
+crontab=$(crontab -l)
+
+# Output cron settings to console
+printf "Cron job set as: \n$crontab\n"
+
+# Start Cron
+crond -f -L /dev/stdout


### PR DESCRIPTION
Added ENV vars for crontab, removed old file/way of doing things.

Two new ENV vars have been added:

```
$CRON
$CRON_COMMAND
```

If these are unset, they will default to Borg defaults.

Example usage:
    environment:
      - CRON=0 5 * * *
      - CRON_COMMAND=borgmatic --stats -v 0 2>&1
      
---

Edit (31/10/2022): https://github.com/borgmatic-collective/docker-borgmatic/pull/150/commits/9a3e29d68bab8c202881b92f49f5e3226d57a0f8 fixes #170 