### PR TITLE
Redirect stderr to docker-error-logs

### DIFF
--- a/base/data/borgmatic.d/crontab.txt
+++ b/base/data/borgmatic.d/crontab.txt
@@ -1,1 +1,1 @@
-0 1 * * * PATH=$PATH:/usr/local/bin /usr/local/bin/borgmatic --stats -v 0 2>&1
+0 1 * * * PATH=$PATH:/usr/local/bin /usr/local/bin/borgmatic --stats -v 0 1>/proc/1/fd/1 2>/proc/1/fd/2


### PR DESCRIPTION
stderr output of processes started by crond are forwarded to stdout (by _tunneling_ it through crond)   This could be solved by redirecting the output of the cron-childs directly to the file descriptors of PID 1