### PR TITLE
fix: use openssl 1.1 with Alpine 3.17

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -10,7 +10,7 @@ VOLUME /root/.cache/borg
 RUN apk add --update --no-cache \
     tzdata \
     sshfs \
-    openssl \
+    openssl1.1-compat \
     fuse \
     ca-certificates \
     logrotate \


### PR DESCRIPTION
Alpine 3.16's included OpenSSL package was 1.1.1. Alpine 3.17 updated it to 3.0.7, which is incompatible with borgbackup. This updates the Dockerfile to pull in the correct library version to avoid this incompatibility.

This resolves https://github.com/borgmatic-collective/docker-borgmatic/issues/180 and https://github.com/borgmatic-collective/docker-borgmatic/issues/184.