### PR TITLE
fix(dockerfile): add mariadb-connector-c

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -30,6 +30,7 @@ RUN apk add --update --no-cache \
     bash \
     bash-completion \
     bash-doc \
+    mariadb-connector-c \
     && rm -rf \
     /var/cache/apk/* \
     /.cache


### PR DESCRIPTION
- newer MySQL versions have changed the `native_password authentication` to `caching_sha2_password` and therefore the mariadb-connector-c alpine package is required for connectivity, also see [MySQL Manual](https://dev.mysql.com/doc/refman/8.0/en/caching-sha2-pluggable-authentication.html)

Closes #176 