### PR TITLE
Remove unnecessary VOLUME definitions in Dockerfile

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,12 +1,8 @@
 # syntax = docker/dockerfile:latest
 FROM python:3.11.2-alpine3.17
 LABEL maintainer='github.com/borgmatic-collective'
-VOLUME /mnt/source
-VOLUME /mnt/borg-repository
 VOLUME /root/.borgmatic
-VOLUME /etc/borgmatic.d
 VOLUME /root/.config/borg
-VOLUME /root/.ssh
 VOLUME /root/.cache/borg
 RUN apk add --update --no-cache \
     bash \

--- a/ntfy/Dockerfile
+++ b/ntfy/Dockerfile
@@ -12,6 +12,5 @@ RUN apk upgrade --no-cache \
 
 FROM ghcr.io/borgmatic-collective/borgmatic:latest
 LABEL mainainer='b3vis'
-VOLUME /root/.config/ntfy
 COPY --from=builder /usr/lib/python3.9/site-packages /usr/lib/python3.9/
 COPY --from=builder /usr/bin/ntfy /usr/bin/


### PR DESCRIPTION
This removes VOLUME definitions for locations in the container where we expect the user to bind their own storage locations or locations where we don't expect the build process to place files.
The impact of this change is that users using docker compose will not see unused but declared VOLUMEs being created as anonymous volumes.