### PR TITLE
add sqlite client

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -24,6 +24,7 @@ RUN apk add --update --no-cache \
     mongodb-tools \
     openssl1.1-compat \
     postgresql-client \
+    sqlite \
     sshfs \
     supercronic \
     tzdata \


### PR DESCRIPTION
borgmatic 1.7.9 now supports sqlite db backups, added sqlite client to fix error when trying to backup sqlite files: `/mnt/borg-repository: Error running actions for repository Command 'sqlite3 /mnt/source/mailcow/data/bitwarden/db.sqlite3 .dump > /root/.borgmatic/sqlite_databases/localhost/bitwarden' returned non-zero exit status 127. /etc/borgmatic.d/config.yaml: Error running configuration file`