### PR TITLE
Fix `create .: volume name is too short`

### DIFF
--- a/base/docker-compose.yml
+++ b/base/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       - ${VOLUME_SOURCE}:/mnt/source:ro            # backup source
       - ${VOLUME_TARGET}:/mnt/borg-repository      # backup target
       - ${VOLUME_ETC_BORGMATIC}:/etc/borgmatic.d/  # borgmatic config file(s) + crontab.txt
-      - ${VOLUME_BORGMATIC_STATE}:/root/.borgmatic # borgmatic state files
+      - ${VOLUME_DOT_BORGMATIC}:/root/.borgmatic   # borgmatic state files
       - ${VOLUME_BORG_CONFIG}:/root/.config/borg   # config and keyfiles
       - ${VOLUME_SSH}:/root/.ssh                   # ssh key for remote repositories
       - ${VOLUME_BORG_CACHE}:/root/.cache/borg     # checksums used for deduplication

--- a/base/docker-compose.yml
+++ b/base/docker-compose.yml
@@ -7,7 +7,6 @@ services:
       - ${VOLUME_SOURCE}:/mnt/source:ro            # backup source
       - ${VOLUME_TARGET}:/mnt/borg-repository      # backup target
       - ${VOLUME_ETC_BORGMATIC}:/etc/borgmatic.d/  # borgmatic config file(s) + crontab.txt
-      - ${VOLUME_DOT_BORGMATIC}:/root/.borgmatic   # borgmatic state files
       - ${VOLUME_BORG_CONFIG}:/root/.config/borg   # config and keyfiles
       - ${VOLUME_SSH}:/root/.ssh                   # ssh key for remote repositories
       - ${VOLUME_BORG_CACHE}:/root/.cache/borg     # checksums used for deduplication


### PR DESCRIPTION
`VOLUME_BORGMATIC_STATE` is not set in the default `.env` file. Instead `VOLUME_BORGMATIC_STATE` is set which results in `WARNING: The VOLUME_BORGMATIC_STATE variable is not set. Defaulting to a blank string.`.

Using an empty string as a volume name in turn results in the following error: `ERROR: for borgmatic  Cannot create container for service borgmatic: create .: volume name is too short, names should be at least two alphanumeric characters`. This makes docker-compose fail to start the container.