### PR TITLE
feat: use docker secrets, fix up markdown

### DIFF
--- a/IMAGE_ARCHITECTURE.md
+++ b/IMAGE_ARCHITECTURE.md
@@ -1,12 +1,14 @@
-```
+# Image Architecture
+
+```plain
 docker-borgmatic/
 ├── data
 │   └── borgmatic.d
 │       ├── config.yml
 │       └── crontab.txt
-├── docker-compose.restore.yml     
+├── docker-compose.restore.yml
 ├── docker-compose.yml
 ├── Dockerfile
 ├── entry.sh
-└── README.md     
+└── README.md
 ```

--- a/docker-compose.restore.yml
+++ b/docker-compose.restore.yml
@@ -2,18 +2,32 @@ version: '3'
 services:
   borgmatic:
     container_name: borg-restore
-
     cap_add:
       - SYS_ADMIN
-
     volumes:
       - /host/mount/location:/restore
-
     security_opt:
       - apparmor:unconfined
       - label:disable
-
     devices:
       - /dev/fuse:/dev/fuse
-
     command: /bin/sh
+    environment:
+      - TZ=${TZ}
+    secrets:
+      - BORG_PASSPHRASE
+      - BORGMATIC_REPO
+      - BORGMATIC_SSH_KEY
+
+# Secrets (https://docs.docker.com/compose/use-secrets/)
+# Any secrets prefixed with BORG will be loaded into the environment when the borgmatic container runs.
+# Generate docker secrets using: echo -n "secret" | docker secret create BORG_PASSPHRASE -
+
+secrets:
+  BORGMATIC_REPO:                                 # borg repository
+    external: true
+  BORG_PASSPHRASE:                                # passphrase for the borg repository
+    external: true
+  BORGMATIC_SSH_KEY:                              # ssh key for remote repositories, stored in a file, loaded by docker secrets
+    external: true
+    file: /some/where/secure/borg_ed25519.key

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,4 +13,20 @@ services:
       - ${VOLUME_BORG_CACHE}:/root/.cache/borg     # checksums used for deduplication
     environment:
       - TZ=${TZ}
-      - BORG_PASSPHRASE=${BORG_PASSPHRASE}
+    secrets:
+      - BORG_PASSPHRASE
+      - BORGMATIC_REPO
+      - BORGMATIC_SSH_KEY
+
+# Secrets (https://docs.docker.com/compose/use-secrets/)
+# Any secrets prefixed with BORG will be loaded into the environment when the borgmatic container runs.
+# Generate docker secrets using: echo -n "secret" | docker secret create BORG_PASSPHRASE -
+
+secrets:
+  BORGMATIC_REPO:                                 # borg repository
+    external: true
+  BORG_PASSPHRASE:                                # passphrase for the borg repository
+    external: true
+  BORGMATIC_SSH_KEY:                              # ssh key for remote repositories, stored in a file, loaded by docker secrets
+    external: true
+    file: /some/where/secure/borg_ed25519.key

--- a/entry.sh
+++ b/entry.sh
@@ -3,18 +3,25 @@
 # Path
 CRONTAB_PATH="/etc/borgmatic.d/crontab.txt"
 
-#Variables
+# Variables
 borgver=$(borg --version)
 borgmaticver=$(borgmatic --version)
 apprisever=$(apprise --version | grep -Eo '[0-9]+\.[0-9]+\.[0-9]+')
 
-#Software versions
-echo borgmatic $borgmaticver
-echo $borgver
-echo apprise $apprisever
+# Software versions
+echo borgmatic "$borgmaticver"
+echo "$borgver"
+echo apprise "$apprisever"
+
+# Load any Docker secrets starting with BORG if they exist
+for secret_file in /run/secrets/BORG*; do
+  secret_name=$(basename "$secret_file")
+  secret_value=$(cat "$secret_file")
+  export "${secret_name}=${secret_value}"
+  echo "Loaded secret ${secret_name}"
+done
 
 if [ $# -eq 0 ]; then
-
   # Allow setting of custom crontab, so check if crontab file exists
   if [ -f "$CRONTAB_PATH" ]; then
     echo "Crontab file exists, using it"
@@ -25,24 +32,24 @@ if [ $# -eq 0 ]; then
     else
       echo "Environment variable BACKUP_CRON is set, using value $BACKUP_CRON"
     fi
-    echo "$BACKUP_CRON PATH=\$PATH:/usr/local/bin /usr/local/bin/borgmatic --stats -v 0 2>&1" > $CRONTAB_PATH
+    echo "$BACKUP_CRON PATH=\$PATH:/usr/local/bin /usr/local/bin/borgmatic --stats -v 0 2>&1" >"$CRONTAB_PATH"
   fi
 
-  if [ "${RUN_ON_STARTUP:-}" == "true" ]; then
+  if [ "${RUN_ON_STARTUP:-}" = "true" ]; then
     echo "Running on startup..."
     /usr/local/bin/borgmatic --stats -v 0 2>&1
   fi
 
   # Test crontab
-  supercronic -test /etc/borgmatic.d/crontab.txt || exit 1
+  supercronic -test "$CRONTAB_PATH" || exit 1
 
   # Start supercronic
   if [ -n "${SUPERCRONIC_EXTRA_FLAGS}" ]; then
     echo "The variable SUPERCRONIC_EXTRA_FLAGS is not empty, using extra flags"
-    exec supercronic $SUPERCRONIC_EXTRA_FLAGS /etc/borgmatic.d/crontab.txt
+    exec supercronic "$SUPERCRONIC_EXTRA_FLAGS" "$CRONTAB_PATH"
   else
     echo "The variable SUPERCRONIC_EXTRA_FLAGS is empty, starting normally"
-    exec supercronic /etc/borgmatic.d/crontab.txt
+    exec supercronic "$CRONTAB_PATH"
   fi
 else
   if [ "$1" = "bash" ] || [ "$1" = "sh" ] || [ "$1" = "/bin/bash" ] || [ "$1" = "/bin/sh" ]; then

--- a/entry.sh
+++ b/entry.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Path
 CRONTAB_PATH="/etc/borgmatic.d/crontab.txt"


### PR DESCRIPTION
- Optionally use Docker secrets to improve security.
- Fixup Markdown (linting/formatting/spelling).
- Minor shell scripting fixes.

Couldn't find a relevant open issue, but does relate to #47