### PR TITLE
use postgresql 16 client in the image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # syntax = docker/dockerfile:latest
-FROM python:3.11.5-alpine3.18
+FROM python:3.11.7-alpine3.19
 LABEL maintainer='github.com/borgmatic-collective'
 VOLUME /mnt/source
 VOLUME /mnt/borg-repository
@@ -22,12 +22,12 @@ RUN apk add --update --no-cache \
     mariadb-client \
     mariadb-connector-c \
     mongodb-tools \
-    openssl1.1-compat \
+    openssl \
     sqlite \
+    postgresql-client \
     sshfs \
     supercronic \
     tzdata \
-    && apk add postgresql16-client --repository=https://dl-cdn.alpinelinux.org/alpine/edge/main --no-cache \
     && rm -rf \
     /var/cache/apk/* \
     /.cache

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ RUN apk add --update --no-cache \
     sshfs \
     supercronic \
     tzdata \
-    && apk add postgresql16-client --repository=https://dl-cdn.alpinelinux.org/alpine/edge/testing --no-cache \
+    && apk add postgresql16-client --repository=https://dl-cdn.alpinelinux.org/alpine/edge/main --no-cache \
     && rm -rf \
     /var/cache/apk/* \
     /.cache

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,11 +23,11 @@ RUN apk add --update --no-cache \
     mariadb-connector-c \
     mongodb-tools \
     openssl1.1-compat \
-    postgresql-client \
     sqlite \
     sshfs \
     supercronic \
     tzdata \
+    && apk add postgresql16-client --repository=https://dl-cdn.alpinelinux.org/alpine/edge/testing --no-cache \
     && rm -rf \
     /var/cache/apk/* \
     /.cache


### PR DESCRIPTION
For now, the client for 16 is only available in edge. This is needed if the user is dumping databases from a postgres 16 server.

Without this, the pg_dump will fail.

This is only temporary until alpine add the 16 client to main