### PR TITLE
[Feature] Add Docker Secrets support

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,13 @@ You can also provide your own crontab file. If `data/borgmatic.d/crontab.txt` ex
 0 1 * * * PATH=$PATH:/usr/bin /usr/bin/borgmatic --stats -v 0 2>&1
 ```
 
-Beside that, you can also pass any environment variable that is supported by borgmatic. See documentation for [borgmatic](https://torsion.org/borgmatic/) and [Borg](https://borgbackup.readthedocs.io/) and for a list of supported variables. 
+Beside that, you can also pass any environment variable that is supported by borgmatic. See documentation for [borgmatic](https://torsion.org/borgmatic/) and [Borg](https://borgbackup.readthedocs.io/) and for a list of supported variables.
+
+### Using Secrets (Optional)
+
+You also have the option to use Docker Secrets for more sensitive information. This is not mandatory, but it adds an extra layer of security. **Note that this feature is only applicable to environment variables starting with `BORG`.**
+
+For every environment variable like `BORG_PASSPHRASE`, you can create a corresponding secret file, named as `BORG_PASSPHRASE_FILE`. Place the content of the secret inside this file. The startup script will automatically look for corresponding `_FILE` secrets if the environment variables are not set and load them.
 
 ## Other usage methods
 

--- a/entry.sh
+++ b/entry.sh
@@ -13,6 +13,50 @@ echo borgmatic $borgmaticver
 echo $borgver
 echo apprise $apprisever
 
+# Uncomment the following lines for debugging to display the initial values of BORG_PASSPHRASE and BORG_PASSPHRASE_FILE.
+# echo "Before: BORG_PASSPHRASE: ${BORG_PASSPHRASE}"
+# echo "Before: BORG_PASSPHRASE_FILE: ${BORG_PASSPHRASE_FILE}"
+
+# Iterate through all environment variables with the prefix 'BORG'.
+for var_name in $(set | grep '^BORG' | awk -F= '{print $1}'); do
+  # Retrieve the current value of the environment variable in question.
+  var_value=$(eval echo \$$var_name)
+
+  # Check if the variable name ends with the suffix '_FILE'.
+  if [[ "$var_name" =~ _FILE$ ]]; then
+    # Remove the '_FILE' suffix to derive the name of the corresponding "non-FILE" variable.
+    original_var_name=${var_name%_FILE}
+
+    # Check if the original (non-FILE) environment variable is already set and capture its value.
+    original_var_value=$(eval echo \$$original_var_name)
+
+    # Verify that the *_FILE variable is set, that the file it points to exists, and that the file is not empty.
+    if [ -n "$var_value" ] && [ -s "$var_value" ]; then
+      # Notify the user if the original (non-FILE) variable is being overwritten.
+      if [ -n "$original_var_value" ]; then
+        echo "Note: $original_var_name was already set but is being overwritten by $var_name"
+      fi
+
+      # Read the file content and store it in the original (non-FILE) environment variable.
+      export "$original_var_name"=$(cat "$var_value")
+      echo "Setting $original_var_name from the content of $var_value"
+
+      # Remove the original *_FILE environment variable
+      unset "$var_name"
+      echo "Unsetting $var_name"
+    else
+      # Issue an error message if the file does not exist or is empty.
+      echo "Error: File $var_value does not exist or is empty."
+    fi
+  fi
+done
+
+# Uncomment the following lines for debugging to display the final values of BORG_PASSPHRASE and BORG_PASSPHRASE_FILE.
+# echo "After: BORG_PASSPHRASE: ${BORG_PASSPHRASE}"
+# echo "After: BORG_PASSPHRASE_FILE: ${BORG_PASSPHRASE_FILE}"
+# exit 1
+
+
 if [ $# -eq 0 ]; then
 
   # Allow setting of custom crontab, so check if crontab file exists

--- a/entry.sh
+++ b/entry.sh
@@ -13,49 +13,53 @@ echo borgmatic $borgmaticver
 echo $borgver
 echo apprise $apprisever
 
-# Uncomment the following lines for debugging to display the initial values of BORG_PASSPHRASE and BORG_PASSPHRASE_FILE.
-# echo "Before: BORG_PASSPHRASE: ${BORG_PASSPHRASE}"
-# echo "Before: BORG_PASSPHRASE_FILE: ${BORG_PASSPHRASE_FILE}"
+# Enable initial debug logging based on the DEBUG_SECRETS environment variable.
+# Logs the initial values of BORG_PASSPHRASE and BORG_PASSPHRASE_FILE.
+if [ "${DEBUG_SECRETS}" = "true" ] || [ "${DEBUG_SECRETS}" = "1" ]; then
+  echo "Before: BORG_PASSPHRASE: ${BORG_PASSPHRASE}"
+  echo "Before: BORG_PASSPHRASE_FILE: ${BORG_PASSPHRASE_FILE}"
+fi
 
-# Iterate through all environment variables with the prefix 'BORG'.
+# Loop through all environment variables that start with 'BORG'.
 for var_name in $(set | grep '^BORG' | awk -F= '{print $1}'); do
-  # Retrieve the current value of the environment variable in question.
+  # Retrieve the current value of each environment variable.
   var_value=$(eval echo \$$var_name)
 
-  # Check if the variable name ends with the suffix '_FILE'.
+  # Check if the variable's name ends with '_FILE'.
   if [[ "$var_name" =~ _FILE$ ]]; then
-    # Remove the '_FILE' suffix to derive the name of the corresponding "non-FILE" variable.
+    # Strip the '_FILE' suffix to obtain the corresponding variable name.
     original_var_name=${var_name%_FILE}
 
-    # Check if the original (non-FILE) environment variable is already set and capture its value.
+    # Retrieve the value of the original environment variable, if it exists.
     original_var_value=$(eval echo \$$original_var_name)
 
-    # Verify that the *_FILE variable is set, that the file it points to exists, and that the file is not empty.
+    # Ensure the *_FILE variable is valid, and the referenced file exists and is not empty.
     if [ -n "$var_value" ] && [ -s "$var_value" ]; then
-      # Notify the user if the original (non-FILE) variable is being overwritten.
+      # Notify user if original variable is being overwritten.
       if [ -n "$original_var_value" ]; then
         echo "Note: $original_var_name was already set but is being overwritten by $var_name"
       fi
 
-      # Read the file content and store it in the original (non-FILE) environment variable.
+      # Update the original variable with the content of the file.
       export "$original_var_name"=$(cat "$var_value")
       echo "Setting $original_var_name from the content of $var_value"
 
-      # Remove the original *_FILE environment variable
+      # Unset the *_FILE environment variable.
       unset "$var_name"
       echo "Unsetting $var_name"
     else
-      # Issue an error message if the file does not exist or is empty.
+      # Issue an error if the *_FILE variable is not properly set, or the file does not exist or is empty.
       echo "Error: File $var_value does not exist or is empty."
     fi
   fi
 done
 
-# Uncomment the following lines for debugging to display the final values of BORG_PASSPHRASE and BORG_PASSPHRASE_FILE.
-# echo "After: BORG_PASSPHRASE: ${BORG_PASSPHRASE}"
-# echo "After: BORG_PASSPHRASE_FILE: ${BORG_PASSPHRASE_FILE}"
-# exit 1
-
+# Enable final debug logging based on the DEBUG_SECRETS environment variable.
+# Logs the final values of BORG_PASSPHRASE and BORG_PASSPHRASE_FILE.
+if [ "${DEBUG_SECRETS}" = "true" ] || [ "${DEBUG_SECRETS}" = "1" ]; then
+  echo "After: BORG_PASSPHRASE: ${BORG_PASSPHRASE}"
+  echo "After: BORG_PASSPHRASE_FILE: ${BORG_PASSPHRASE_FILE}"
+fi
 
 if [ $# -eq 0 ]; then
 


### PR DESCRIPTION
# Implementation of Docker Secrets for `BORG` Environment Variables

Related to Ticket #47 and PR #246, a possible implementation of Docker Secrets is provided here. This implementation has been rigorously tested and documented. A key feature is that the use of standard environment variables within Docker commands or `docker-compose.yml` files is preserved. This ensures that those who do not wish to use [Docker Secrets](https://docs.docker.com/compose/use-secrets/) can continue to operate as before.

## Functionality

The function iterates through all environment variables that begin with `BORG`, such as `BORG_PASSPHRASE`. It then looks for variables that end with `_FILE`. The contents of such a `_FILE` variable are written to a new variable, the name of which excludes the `_FILE` suffix. 

> [!NOTE]
> This implementation prioritizes Secrets over regularly set variables.

## Debugging

@grantbevis for testing purposes, debugging capabilities have been added. To enable debugging, set the environment variable `DEBUG_SECRETS=true`.

## Permissions
The script also works when the Docker-required `chmod 600` permissions are set on the secret files.

## Testing

### Test 1
**Environment:**
```yaml
    environment:
      - DEBUG_SECRETS=true
      - BORG_PASSPHRASE=OldSchoolEnvironment
```
**Result:**
```
borgmatic  | Before: BORG_PASSPHRASE: OldSchoolEnvironment
borgmatic  | Before: BORG_PASSPHRASE_FILE: 
borgmatic  | After: BORG_PASSPHRASE: OldSchoolEnvironment
borgmatic  | After: BORG_PASSPHRASE_FILE: 
```
---
### Test 2
**Environment:**
```yaml
    environment:
      - DEBUG_SECRETS=true
      - BORG_PASSPHRASE_FILE=/run/secrets/borg_passphrase
    secrets:
      - borg_passphrase
secrets:
  borg_passphrase:
    file: ./borg_passphrase
```
**Result:**
```
borgmatic  | Before: BORG_PASSPHRASE: 
borgmatic  | Before: BORG_PASSPHRASE_FILE: /run/secrets/borg_passphrase
borgmatic  | Setting BORG_PASSPHRASE from the content of /run/secrets/borg_passphrase
borgmatic  | Unsetting BORG_PASSPHRASE_FILE
borgmatic  | After: BORG_PASSPHRASE: ThisIsFromTheSecretFile
borgmatic  | After: BORG_PASSPHRASE_FILE: 
```
---
### Test 3
**Environment:**
```yaml
    environment:
      - DEBUG_SECRETS=true
      - BORG_PASSPHRASE=OldSchoolEnvironment
      - BORG_PASSPHRASE_FILE=
    secrets:
      - borg_passphrase
secrets:
  borg_passphrase:
    file: ./borg_passphrase
```
**Result:**
```
borgmatic  | Before: BORG_PASSPHRASE: OldSchoolEnvironment
borgmatic  | Before: BORG_PASSPHRASE_FILE: 
borgmatic  | Error: File  does not exist or is empty.
borgmatic  | After: BORG_PASSPHRASE: OldSchoolEnvironment
borgmatic  | After: BORG_PASSPHRASE_FILE: 
```
---
### Test 4
**Environment:**
```yaml
    environment:
      - DEBUG_SECRETS=true
      - BORG_PASSPHRASE=
      - BORG_PASSPHRASE_FILE=/run/secrets/borg_passphrase
    secrets:
      - borg_passphrase
secrets:
  borg_passphrase:
    file: ./borg_passphrase
```
**Result:**
```
borgmatic  | Before: BORG_PASSPHRASE: 
borgmatic  | Before: BORG_PASSPHRASE_FILE: /run/secrets/borg_passphrase
borgmatic  | Setting BORG_PASSPHRASE from the content of /run/secrets/borg_passphrase
borgmatic  | Unsetting BORG_PASSPHRASE_FILE
borgmatic  | After: BORG_PASSPHRASE: ThisIsFromTheSecretFile
borgmatic  | After: BORG_PASSPHRASE_FILE: 
```
---
### Test 5
**Environment:**
```yaml
    environment:
      - DEBUG_SECRETS=true
      - BORG_PASSPHRASE=
      - BORG_PASSPHRASE_FILE=/run/secrets/borg_passphrase
    secrets:
      - borg_passphrase
secrets:
  borg_passphrase:
    file: ./borg_passphrase
```
**Result:**
```
borgmatic  | Before: BORG_PASSPHRASE: OldSchoolEnvironment
borgmatic  | Before: BORG_PASSPHRASE_FILE: /run/secrets/borg_passphrase
borgmatic  | Note: BORG_PASSPHRASE was already set but is being overwritten by BORG_PASSPHRASE_FILE
borgmatic  | Setting BORG_PASSPHRASE from the content of /run/secrets/borg_passphrase
borgmatic  | Unsetting BORG_PASSPHRASE_FILE
borgmatic  | After: BORG_PASSPHRASE: ThisIsFromTheSecretFile
borgmatic  | After: BORG_PASSPHRASE_FILE: 
```