### PR TITLE
[Update] Update config.yaml to Address Deprecated Options

### DIFF
--- a/data/borgmatic.d/config.yaml
+++ b/data/borgmatic.d/config.yaml
@@ -1,35 +1,34 @@
-location:
-    source_directories:
-        - /mnt/source
-    repositories:
-        - /mnt/borg-repository
-    one_file_system: true
+source_directories:
+    - /mnt/source
+repositories:
+    - /mnt/borg-repository
+one_file_system: true
 
-storage:
+
 #   Passphrase is set in variable $BORG_PASSPHRASE
 #   encryption_passphrase: "DoNotMissToChangeYourPassphrase"
-    compression: lz4
-    archive_name_format: 'backup-{now}'
+compression: lz4
+archive_name_format: 'backup-{now}'
 
-retention:
-    keep_hourly: 2
-    keep_daily: 7
-    keep_weekly: 4
-    keep_monthly: 12
-    keep_yearly: 10
-    prefix: 'backup-'
 
-consistency:
-    checks:
-        - repository
-        - archives
-    check_last: 3
-    prefix: 'backup-'
+keep_hourly: 2
+keep_daily: 7
+keep_weekly: 4
+keep_monthly: 12
+keep_yearly: 10
 
-hooks:
-    before_backup:
-        - echo "Starting a backup job."
-    after_backup:
-        - echo "Backup created."
-    on_error:
-        - echo "Error while creating a backup."
+
+
+checks:
+    - name: repository
+    - name: archives
+check_last: 3
+
+
+
+before_backup:
+    - echo "Starting a backup job."
+after_backup:
+    - echo "Backup created."
+on_error:
+    - echo "Error while creating a backup."


### PR DESCRIPTION
### Description
While working on PR #275, I noticed that various options in the `config.yaml` are marked as deprecated and are slated for removal in future releases. The following warnings were issued:

``` 
/etc/borgmatic.d/config.yml: Configuration sections (like location:, storage:, retention:, consistency:, and hooks:) are deprecated and support will be removed from a future release. To prepare for this, move your options out of sections to the global scope.                                                                                                                                                             
/etc/borgmatic.d/config.yml: The checks option now expects a list of key/value pairs. Lists of strings for this option are deprecated and support will be removed from a future release.                                                                                                                                                                                                                                       
/etc/borgmatic.d/config.yml: The prefix option is deprecated and support will be removed from a future release. Use archive_name_format or match_archives instead. 
```

To address these, I've updated the `config.yaml` based on the official documentation [here](https://torsion.org/borgmatic/docs/reference/configuration/). The updated configuration works as expected, but without the deprecated warnings.