### PR TITLE
Mention borgmatic 1.8.9+ Apprise log sending capability.

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,15 +173,7 @@ apprise:
         body: Your backups have failed.
 ```
 
-#### Important Note
-
-Just like in the previous configuration, you can use `$(cat /tmp/backup_run.log)` to send log outputs as part of the notification body. Simply replace the `body` value with this variable to include the log in your notifications.
-
-```yaml
-    finish:
-        title: ✅ SUCCESS
-        body: $(cat /tmp/backup_run.log)
-```
+And as of borgmatic 1.8.9+, borgmatic's logs are automatically appended to the `body` for each notification.
 
 ### Conclusion
 


### PR DESCRIPTION
As part of this PR, I've removed an outdated (and incorrect) method for sending borgmatic's logs to Apprise and called out the new borgmatic 1.8.9 built-in approach.

Also: I haven't done it here, but I might suggest updating the docs to remove the old manual way for sending borgmatic logs to Apprise—or at least swapping the order so the new "native" way comes first. I'd be happy to do this if that's something you're interested in.