### PR TITLE
change CRON ENV to BACKUP_CRON as stated in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ You can set the following environment variables:
 
 You can also provide your own crontab file. If `data/borgmatic.d/crontab.txt` exists, `BACKUP_CRON` will be ignored in preference to it. In here you can add any other tasks you want ran
 ```
-0 1 * * * PATH=$PATH:/usr/bin /usr/bin/borgmatic --stats -v 0 2>&1
+0 1 * * * PATH=$PATH:/usr/local/bin /usr/local/bin/borgmatic --stats -v 0 2>&1
 ```
 
 Beside that, you can also pass any environment variable that is supported by borgmatic. See documentation for [borgmatic](https://torsion.org/borgmatic/) and [Borg](https://borgbackup.readthedocs.io/) and for a list of supported variables.
@@ -102,7 +102,7 @@ To enhance your experience with Borgmatic, we'll show you a quick example of how
 In an unmodified Borgmatic installation, your `cronjob.txt` might look something like this:
 
 ```
-0 1 * * * PATH=$PATH:/usr/local/bin /usr/local/bin/borgmatic --stats -v 0 2>&1
+0 1 * * * /usr/local/bin/borgmatic --stats -v 0 2>&1
 ```
 
 To incorporate Apprise notifications, you can modify it like this:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,6 @@ services:
       - ${VOLUME_SOURCE}:/mnt/source:ro            # backup source
       - ${VOLUME_TARGET}:/mnt/borg-repository      # backup target
       - ${VOLUME_ETC_BORGMATIC}:/etc/borgmatic.d/  # borgmatic config file(s) + crontab.txt
-      - ${VOLUME_BORGMATIC_STATE}:/root/.borgmatic # borgmatic state files
       - ${VOLUME_BORG_CONFIG}:/root/.config/borg   # config and keyfiles
       - ${VOLUME_SSH}:/root/.ssh                   # ssh key for remote repositories
       - ${VOLUME_BORG_CACHE}:/root/.cache/borg     # checksums used for deduplication

--- a/root/etc/s6-overlay/s6-rc.d/svc-cron/run
+++ b/root/etc/s6-overlay/s6-rc.d/svc-cron/run
@@ -88,17 +88,17 @@ if [ "${DEBUG_SECRETS}" = "true" ] || [ "${DEBUG_SECRETS}" = "1" ]; then
 fi
 
 # Disable cron if it's set to disabled.
-if [[ "$CRON" = "false" ]]; then
+if [[ "$BACKUP_CRON" = "false" ]]; then
     echo "Disabling cron, removing configuration"
     # crontab -r # quite destructive
     # echo -n > /etc/crontabs/root # Empty config, doesn't look as nice with "crontab -l"
     echo "# Cron disabled" > /etc/crontabs/root
     echo "Cron is now disabled"
-# Apply default or custom cron if $CRON is unset or set (not null):
-elif [[ -v CRON ]]; then
-    CRON="${CRON:-"0 1 * * *"}"
-    CRON_COMMAND="${CRON_COMMAND:-"borgmatic --stats -v 0 2>&1"}"
-    echo "$CRON $CRON_COMMAND" > /etc/crontabs/root
+# Apply default or custom cron if $BACKUP_CRON is unset or set (not null):
+elif [[ -v BACKUP_CRON ]]; then
+    BACKUP_CRON="${BACKUP_CRON:-"0 1 * * *"}"
+    CRON_COMMAND="${CRON_COMMAND:-"/usr/local/bin/borgmatic --stats -v 0 2>&1"}"
+    echo "$BACKUP_CRON $CRON_COMMAND" > /etc/crontabs/root
     echo "Applying custom cron"
 # If nothing is set, revert to default behaviour
 else


### PR DESCRIPTION
As of README.md, cron time can be set via ENV `BACKUP_CRON`, but init script uses `CRON` instead.

This commit changes init script, so `BACKUP_CRON` is used.

Additional minor changes:
- `docke-compose.yml`: remove volume for `/root/.borgmatic` (as README.md says this is redundant and should be removed)
- fix README.md: script lives in `/usr/local/bin/` instead of `/usr/bin/`
- fix README.md: in default `crontab.txt`, there is no $PATH set