### PR TITLE
Fixed entrypoint when using docker-compose.restore.yml

### DIFF
--- a/docker-compose.restore.yml
+++ b/docker-compose.restore.yml
@@ -10,4 +10,5 @@ services:
       - label:disable
     devices:
       - /dev/fuse:/dev/fuse
+    entrypoint: ''
     command: /bin/sh


### PR DESCRIPTION
I was losely following the restore instructions in your README.md.
But the `command: /bin/sh` in the `docker-compose.restore.yml` wasn't enough to land me in an interactive shell using `ghcr.io/borgmatic-collective/borgmatic:latest` when doing a `docker-compose -f docker-compose.yml -f docker-compose.restore.yml run borgmatic`.

Clearing the entrypoint fixed that.