### PR TITLE
remove duplicated hooks

### DIFF
--- a/data/borgmatic.d/config.yaml
+++ b/data/borgmatic.d/config.yaml
@@ -25,14 +25,6 @@ checks:
   - name: data
     frequency: 1 month
 
-hooks:
-    before_backup:
-        - echo "Starting a backup job."
-    after_backup:
-        - echo "Backup created."
-    on_error:
-        - echo "Error while creating a backup."
-
 before_everything:
     - echo "Starting a backup job."
 after_everything:


### PR DESCRIPTION
The configuration sections have been deprecated so the hooks should be at root level only.

see #348