### PR TITLE
Update README.md and Dockerfile to reflect new location of statefiles.

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ The following volumes are available for mounting:
 | `/mnt/borg-repository` | Mount your borg backup repository here. |
 | `/etc/borgmatic.d` | Where you need to create crontab.txt and your borgmatic config.yml |
 | `/root/.borgmatic` | **Note** this is now redundant and has been deprecated, please remove this from your configs |
-| `/root/.local/state/borgmatic` | Here are the state files for periodic checks, prunes, and other things. |
+| `/root/.local/state/borgmatic` | Here are the state files for periodic checks. |
 | `/root/.config/borg` | Here the borg config and keys for keyfile encryption modes are stored. Make sure to backup your keyfiles! Also needed when encryption is set to none. |
 | `/root/.ssh` | Mount either your own .ssh here or create a new one with ssh keys in for your remote repo locations. |
 | `/root/.cache/borg` | A non-volatile place to store the borg chunk cache. |

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ docker run \
   -v ./data/.config/borg:/root/.config/borg \
   -v ./data/.ssh:/root/.ssh \
   -v ./data/.cache/borg:/root/.cache/borg \
+  -v ./data/.state/borgmatic:/root/.local/state/borgmatic \
   -e TZ=Europe/Berlin \
   ghcr.io/borgmatic-collective/borgmatic
 ```
@@ -78,6 +79,7 @@ The following volumes are available for mounting:
 | `/mnt/borg-repository` | Mount your borg backup repository here. |
 | `/etc/borgmatic.d` | Where you need to create crontab.txt and your borgmatic config.yml |
 | `/root/.borgmatic` | **Note** this is now redundant and has been deprecated, please remove this from your configs |
+| `/root/.local/state/borgmatic` | Here are the state files for periodic checks, prunes, and other things. |
 | `/root/.config/borg` | Here the borg config and keys for keyfile encryption modes are stored. Make sure to backup your keyfiles! Also needed when encryption is set to none. |
 | `/root/.ssh` | Mount either your own .ssh here or create a new one with ssh keys in for your remote repo locations. |
 | `/root/.cache/borg` | A non-volatile place to store the borg chunk cache. |


### PR DESCRIPTION
Since Borgmatic v1.9.0, state files for periodic checks are saved at ``/root/.local/state/borgmatic``, the documentation should be updated, as wel as the volume reference in the Dockerfile.
Note: The Dockerfile is another pull Request. I'm new to this... sorry :)