### PR TITLE
Update Dockerfile to reflect new state files path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -76,7 +76,7 @@ EOF
 
 COPY --chmod=744 --link root/ /
 
-VOLUME /root/.borgmatic
+VOLUME /root/.local/state/borgmatic
 VOLUME /root/.config/borg
 VOLUME /root/.cache/borg
 


### PR DESCRIPTION
Since Borgmatic v1.9.0, state files for periodic checks are saved at ``/root/.local/state/borgmatic``, the documentation should be updated, as wel as the volume reference in the Dockerfile.
