### PR TITLE
Added borgmatic state volume to compose.yaml and env.template

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -6,3 +6,4 @@ VOLUME_ETC_BORGMATIC=./data/borgmatic.d
 VOLUME_BORG_CONFIG=./data/.config/borg
 VOLUME_SSH=./data/.ssh
 VOLUME_BORG_CACHE=./data/.cache/borg
+VOLUME_BORGMATIC_STATE=./data/.state/borgmatic

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,12 +3,13 @@ services:
     image: ghcr.io/borgmatic-collective/borgmatic
     container_name: borgmatic
     volumes:
-      - ${VOLUME_SOURCE}:/mnt/source:ro            # backup source
-      - ${VOLUME_TARGET}:/mnt/borg-repository      # backup target
-      - ${VOLUME_ETC_BORGMATIC}:/etc/borgmatic.d/  # borgmatic config file(s) + crontab.txt
-      - ${VOLUME_BORG_CONFIG}:/root/.config/borg   # config and keyfiles
-      - ${VOLUME_SSH}:/root/.ssh                   # ssh key for remote repositories
-      - ${VOLUME_BORG_CACHE}:/root/.cache/borg     # checksums used for deduplication
+      - ${VOLUME_SOURCE}:/mnt/source:ro                        # backup source
+      - ${VOLUME_TARGET}:/mnt/borg-repository                  # backup target
+      - ${VOLUME_ETC_BORGMATIC}:/etc/borgmatic.d/              # borgmatic config file(s) + crontab.txt
+      - ${VOLUME_BORG_CONFIG}:/root/.config/borg               # config and keyfiles
+      - ${VOLUME_SSH}:/root/.ssh                               # ssh key for remote repositories
+      - ${VOLUME_BORG_CACHE}:/root/.cache/borg                 # checksums used for deduplication
+      - ${VOLUME_BORGMATIC_STATE}:/root/.local/state/borgmatic # repository checks state
     environment:
       - TZ=${TZ}
       - BORG_PASSPHRASE=${BORG_PASSPHRASE}


### PR DESCRIPTION
Without properly mounted state borgmatic ends up losing accumulated checks state after each `docker compose down`.

Added new environment variable to resolve that.