### PR TITLE
Added tag that pins to major version

### DIFF
--- a/.github/workflows/build_new_version.yml
+++ b/.github/workflows/build_new_version.yml
@@ -25,6 +25,7 @@ jobs:
             # latest tag is applied automatically for semver type in auto mode
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
 
       - name: Prepare Base Build Metadata | GHCR
         id: meta_base_ghcr
@@ -38,6 +39,7 @@ jobs:
             # latest tag is applied automatically for semver type in auto mode
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@master

--- a/README.md
+++ b/README.md
@@ -12,6 +12,22 @@
 
 This repository provides a Docker image for [borgmatic](https://github.com/witten/borgmatic), a simple and efficient backup tool based on [Borgbackup](https://github.com/borgbackup). The image is designed to make it easy to set up and run borgmatic (with Borg and optionally Cron daemon) within a Docker container, enabling you to streamline your backup process and ensure the safety of your data.
 
+### Docker Image Tags
+
+The following Docker image tags are available:
+
+- `1.8.13` - Specific version 1.8.13
+- `1.8.12` - Specific version 1.8.12
+- `1.8` - Latest 1.8.x version (currently 1.8.13)
+- `1` - Latest 1.x.x version (currently 1.8.13)
+- `latest` - Latest version (currently 1.8.13)
+
+This tagging system allows you to pin to your preferred level of version stability:
+- Pin to a specific version (e.g., `1.8.13`) for maximum stability
+- Pin to a minor version (e.g., `1.8`) to receive patch updates only
+- Pin to a major version (e.g., `1`) to receive minor and patch updates, but not major version changes
+- Use `latest` to always get the most recent version
+
 > **Warning**
 > As of 2023-06-23 msmtp and ntfy flavors have been discontinued. This image has now switched to apprise.
 

--- a/README.md
+++ b/README.md
@@ -12,22 +12,6 @@
 
 This repository provides a Docker image for [borgmatic](https://github.com/witten/borgmatic), a simple and efficient backup tool based on [Borgbackup](https://github.com/borgbackup). The image is designed to make it easy to set up and run borgmatic (with Borg and optionally Cron daemon) within a Docker container, enabling you to streamline your backup process and ensure the safety of your data.
 
-### Docker Image Tags
-
-The following Docker image tags are available:
-
-- `1.8.13` - Specific version 1.8.13
-- `1.8.12` - Specific version 1.8.12
-- `1.8` - Latest 1.8.x version (currently 1.8.13)
-- `1` - Latest 1.x.x version (currently 1.8.13)
-- `latest` - Latest version (currently 1.8.13)
-
-This tagging system allows you to pin to your preferred level of version stability:
-- Pin to a specific version (e.g., `1.8.13`) for maximum stability
-- Pin to a minor version (e.g., `1.8`) to receive patch updates only
-- Pin to a major version (e.g., `1`) to receive minor and patch updates, but not major version changes
-- Use `latest` to always get the most recent version
-
 > **Warning**
 > As of 2023-06-23 msmtp and ntfy flavors have been discontinued. This image has now switched to apprise.
 
@@ -146,6 +130,22 @@ If you want to initialize a repository manually or start a backup outside of the
   ```
   docker exec borgmatic /bin/sh -c 'export BORG_PASSPHRASE=$(cat /run/s6/container_environment/BORG_PASSPHRASE) && borgmatic create --stats -v 0'
   ```
+
+### Docker Image Tags
+
+The following Docker image tags are available (assuming 1.8.13 is the latest release):
+
+- `1.8.13` - Specific version 1.8.13
+- `1.8.12` - Specific version 1.8.12
+- `1.8` - Latest 1.8.x version (currently 1.8.13)
+- `1` - Latest 1.x.x version (currently 1.8.13)
+- `latest` - Latest version (currently 1.8.13)
+
+This tagging system allows you to pin to your preferred level of version stability:
+- Pin to a specific version (e.g., `1.8.13`) for maximum stability
+- Pin to a minor version (e.g., `1.8`) to receive patch updates only
+- Pin to a major version (e.g., `1`) to receive minor and patch updates, but not major version changes
+- Use `latest` to always get the most recent version
 
 ## Using Apprise for Notifications
 


### PR DESCRIPTION
As described in #351. Seems like an easy change that can add some good functionality. Personally, I want to avoid moving to 2.0 until it's a bit better vetted, so I would use this immediately.