### PR TITLE
Update cron configuration logic for unset BACKUP_CRON env

### DIFF
--- a/root/etc/s6-overlay/s6-rc.d/svc-cron/run
+++ b/root/etc/s6-overlay/s6-rc.d/svc-cron/run
@@ -54,11 +54,11 @@ if [[ "$BACKUP_CRON" = "false" ]]; then
 elif [[ -n "$BACKUP_CRON" ]]; then
     CRON_COMMAND="${CRON_COMMAND:-$DEFAULT_CRON_COMMAND}"
     echo "$BACKUP_CRON $CRON_COMMAND" > /etc/crontabs/root
-    echo "Applying custom cron"
+    echo "Applying custom cron from env"
 
 # Case 3: BACKUP_CRON is unset or empty, and crontab.txt exists → use crontab file
 elif [[ -f "$CRONTAB_FILE" ]]; then
-    echo "Applying file crontab.txt"
+    echo "Applying cron from file $CRONTAB_FILE"
     crontab "$CRONTAB_FILE"
 
 # Case 4: BACKUP_CRON is unset or empty, and crontab.txt doesn't exist → use defaults

--- a/root/etc/s6-overlay/s6-rc.d/svc-cron/run
+++ b/root/etc/s6-overlay/s6-rc.d/svc-cron/run
@@ -40,23 +40,31 @@ then
   echo "-----------------------------------"
 fi
 
-# Disable cron if it's set to disabled.
+
+DEFAULT_BACKUP_CRON="0 1 * * *"
+DEFAULT_CRON_COMMAND="/usr/local/bin/borgmatic --stats -v 0 2>&1"
+CRONTAB_FILE="/etc/borgmatic.d/crontab.txt"
+
+# Case 1: BACKUP_CRON is explicitly set to "false" → disable cron
 if [[ "$BACKUP_CRON" = "false" ]]; then
-    echo "Disabling cron, removing configuration"
-    # crontab -r # quite destructive
-    # echo -n > /etc/crontabs/root # Empty config, doesn't look as nice with "crontab -l"
     echo "# Cron disabled" > /etc/crontabs/root
-    echo "Cron is now disabled"
-# Apply default or custom cron if $BACKUP_CRON is unset or set (not null):
-elif [[ -v BACKUP_CRON ]]; then
-    BACKUP_CRON="${BACKUP_CRON:-"0 1 * * *"}"
-    CRON_COMMAND="${CRON_COMMAND:-"/usr/local/bin/borgmatic --stats -v 0 2>&1"}"
+    echo "Cron is disabled"
+
+# Case 2: BACKUP_CRON is set and non-empty → use custom schedule
+elif [[ -n "$BACKUP_CRON" ]]; then
+    CRON_COMMAND="${CRON_COMMAND:-$DEFAULT_CRON_COMMAND}"
     echo "$BACKUP_CRON $CRON_COMMAND" > /etc/crontabs/root
     echo "Applying custom cron"
-# If nothing is set, revert to default behaviour
+
+# Case 3: BACKUP_CRON is unset or empty, and crontab.txt exists → use crontab file
+elif [[ -f "$CRONTAB_FILE" ]]; then
+    echo "Applying file crontab.txt"
+    crontab "$CRONTAB_FILE"
+
+# Case 4: BACKUP_CRON is unset or empty, and crontab.txt doesn't exist → use defaults
 else
-    echo "Applying crontab.txt"
-    crontab /etc/borgmatic.d/crontab.txt
+    echo "$DEFAULT_BACKUP_CRON $DEFAULT_CRON_COMMAND" > /etc/crontabs/root
+    echo "Applying default cron"
 fi
 
 # Apply extra cron if it's set


### PR DESCRIPTION
Fixes cron configuration logic to correctly handle when BACKUP_CRON is unset, empty, or explicitly set.

The previous implementation (introduced in PR #397 and reverted in PR #410 after issues reported in #408) used -z to check for an unset BACKUP_CRON, which caused incorrect behavior. Specifically, it skipped the crontab file fallback when BACKUP_CRON was truly unset.

This update replaces the faulty -z check with proper conditionals that now clearly distinguish between:
1. BACKUP_CRON="false" → disables cron
2. BACKUP_CRON is set and non-empty → uses the provided schedule
3. BACKUP_CRON is unset or empty and a crontab.txt file exists → uses the file
4. Otherwise → falls back to default values