### PR TITLE
fix: bash completions script different from installed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -71,7 +71,7 @@ RUN --mount=type=cache,id=pip,target=/root/.cache,sharing=locked \
     set -xe
     python3 -m pip install -U pip
     python3 -m pip install -Ur requirements.txt
-    apk add --no-cache -U borgmatic-bash-completion
+    borgmatic --bash-completion > /usr/share/bash-completion/completions/borgmatic
 EOF
 
 COPY --chmod=744 --link root/ /


### PR DESCRIPTION
Simple fix for misalignment:

<pre>
Your bash completions script is from a different version of borgmatic than is
currently installed. Please upgrade your script so your completions match the
command-line flags in your installed borgmatic! Try this to upgrade:

    sudo sh -c "borgmatic --bash-completion > /usr/share/bash-completion/completions/borgmatic"
    source /usr/share/bash-completion/completions/borgmatic
</pre>

