### PR TITLE
Add optional keepassxc-cli shim via pykeepass

### DIFF
--- a/data/borgscripts/KEEPASSXC-CLI.md
+++ b/data/borgscripts/KEEPASSXC-CLI.md
@@ -1,0 +1,164 @@
+# KeePassXC credential support
+
+This image does not include `keepassxc-cli` by default because the only Alpine
+package available (`keepassxc`) pulls in the full Qt6 GUI stack — adding
+~150 MB to an image that is otherwise under 200 MB. That trade-off is not
+reasonable for users who never touch KeePass.
+
+Instead, this image ships a lightweight Python shim that replicates the exact
+CLI interface that borgmatic calls. You opt in by mounting a single init script
+at container startup. **No changes to borgmatic itself are needed.**
+
+---
+
+## How the shim works (note for borgmatic developers)
+
+borgmatic calls `keepassxc-cli` like this:
+
+```
+keepassxc-cli show --show-protected --attributes Password \
+    [--no-password] [--key-file /path/to/key] \
+    /path/to/database.kdbx "entry-title"
+```
+
+The shim at `/usr/local/bin/keepassxc-cli` accepts the same arguments and
+flags, uses [`pykeepass`](https://github.com/libkeepass/pykeepass) (a
+pure-Python KeePass 4 reader) to open the database, and prints the requested
+attribute to stdout — identical output to the real `keepassxc-cli`.
+
+Because the interface is identical, borgmatic does not need to know or care
+that it is talking to a Python script instead of the real binary. The
+`keepassxc_cli_command` config option can be left at its default
+(`keepassxc-cli`) since the shim is installed at the same path.
+
+Supported flags: `--show-protected`, `--attributes`/`-a`, `--no-password`,
+`--key-file`/`-k`, `--yubikey` (accepted silently — hardware tokens are not
+supported). Attribute lookup covers `Password`, `UserName`, `URL`, `Notes`,
+`Title`, and custom attributes. Group-path style entry names
+(`Group/Entry`) are supported.
+
+---
+
+## Setup
+
+### 1. Mount the init script
+
+Add a volume mount to your `docker-compose.yml`:
+
+```yaml
+services:
+  borgmatic:
+    volumes:
+      # ... your existing volumes ...
+      - ./data/borgscripts/init-keepassxc-cli.sh:/custom-cont-init.d/init-keepassxc-cli.sh:ro
+```
+
+At startup the script installs `pykeepass` (~2 MB, no system packages) and
+writes the `keepassxc-cli` shim to `/usr/local/bin/keepassxc-cli`.
+
+### 2. Mount your KeePass database (and key file, if used)
+
+```yaml
+    volumes:
+      - /path/to/your/passwords.kdbx:/etc/borgmatic/passwords.kdbx:ro
+      - /path/to/your/passwords.keyx:/run/secrets/keepass.keyx:ro  # optional
+```
+
+Keep the database and key file outside your backup source so they are not
+backed up to themselves.
+
+### 3. Configure borgmatic
+
+Add a `keepassxc:` block to your borgmatic config:
+
+```yaml
+keepassxc:
+    database: /etc/borgmatic/passwords.kdbx
+
+    # Set to false to use a key file instead of typing a password at startup.
+    # Required for unattended/scheduled backups.
+    ask_for_password: false
+
+    # Optional — omit if your database is password-protected only.
+    key_file: /run/secrets/keepass.keyx
+```
+
+Then reference credentials anywhere a password is expected:
+
+```yaml
+# Borg repository passphrase
+encryption_passphrase: "{credential keepassxc /etc/borgmatic/passwords.kdbx MyBorgEntry}"
+
+# Database hook credentials
+postgresql_databases:
+    - name: mydb
+      username: "{credential keepassxc /etc/borgmatic/passwords.kdbx PostgresUser}"
+      password: "{credential keepassxc /etc/borgmatic/passwords.kdbx PostgresPassword}"
+```
+
+The value in quotes (`MyBorgEntry`, `PostgresUser`, etc.) is the **title** of
+the entry inside your KeePass database.
+
+### 4. Verify at startup
+
+When the container starts you should see:
+
+```
+[init-keepassxc-cli] Installing pykeepass...
+[init-keepassxc-cli] Writing /usr/local/bin/keepassxc-cli shim...
+[init-keepassxc-cli] Done. keepassxc-cli shim is ready.
+```
+
+Run a manual check to confirm borgmatic can reach the database:
+
+```console
+docker exec -it borgmatic borgmatic config validate
+```
+
+---
+
+## Unattended backups and key files
+
+`keepassxc-cli` normally prompts for the database master password interactively,
+which breaks scheduled (cron) backups. Use a key file instead and set
+`ask_for_password: false` in your borgmatic config — the shim will open the
+database with the key file alone, no prompt.
+
+Store the key file outside your container (e.g. in a Docker secret or a
+host path not included in your backup source) and mount it read-only.
+
+---
+
+## Limitations
+
+### Secret Service integration is not supported
+
+borgmatic supports a `{credential keepassxc secret-service <key>}` syntax that
+retrieves credentials via the D-Bus Secret Service API — the mechanism desktop
+apps use to talk to a running KeePassXC or GNOME Keyring instance.
+
+This does **not** work in a headless Docker container. The Secret Service API
+requires a running D-Bus session bus and a Secret Service provider (KeePassXC
+GUI or `gnome-keyring-daemon`) — neither of which exist in a container, and
+providing them would pull in the full Qt6/GTK desktop stack that this shim
+exists to avoid.
+
+**For unattended Docker backups, use the key file approach** (`ask_for_password:
+false` + `key_file`). It requires no interactive prompt and no running desktop
+environment.
+
+---
+
+## Security notes
+
+- The `pykeepass` library reads the KeePass 4 (`.kdbx`) format entirely
+  in-process — the database is never sent anywhere.
+- The shim prints the requested attribute to stdout exactly as
+  `keepassxc-cli` does; borgmatic captures it in memory and never writes it
+  to disk.
+- `pykeepass` is installed at container startup rather than baked into the
+  image, so it is covered by your normal image rebuild/update cycle via
+  `docker compose pull`.
+- Pin the version if you need reproducible builds:
+  edit `init-keepassxc-cli.sh` and change
+  `pip install pykeepass` to `pip install pykeepass==<version>`.

--- a/data/borgscripts/init-keepassxc-cli.sh
+++ b/data/borgscripts/init-keepassxc-cli.sh
@@ -1,0 +1,111 @@
+#!/bin/bash
+# Optional custom init script — mount at /custom-cont-init.d/init-keepassxc-cli.sh
+#
+# Installs a lightweight keepassxc-cli shim using pykeepass (pure Python,
+# no Qt/GUI dependencies) so borgmatic can retrieve credentials from a
+# KeePass database.
+#
+# Usage in borgmatic config:
+#   keepassxc:
+#     keepassxc_cli_command: /usr/local/bin/keepassxc-cli
+#     database: /path/to/passwords.kdbx
+#     ask_for_password: false       # use key_file instead
+#     key_file: /run/secrets/keepass.keyx   # optional
+#
+# Then reference credentials in your config:
+#   encryption_passphrase: "{credential keepassxc /path/to/passwords.kdbx MyEntry}"
+
+set -e
+
+echo "[init-keepassxc-cli] Installing pykeepass..."
+pip install --quiet --no-cache-dir pykeepass
+
+echo "[init-keepassxc-cli] Writing /usr/local/bin/keepassxc-cli shim..."
+cat > /usr/local/bin/keepassxc-cli << 'SHIM'
+#!/usr/bin/env python3
+"""
+Minimal keepassxc-cli shim backed by pykeepass.
+Implements the subset of keepassxc-cli that borgmatic calls:
+  keepassxc-cli show --show-protected --attributes <attr>
+                     [--no-password] [--key-file <file>]
+                     <database> <entry>
+"""
+import argparse
+import sys
+
+try:
+    from pykeepass import PyKeePass
+    from pykeepass.exceptions import CredentialsError
+except ImportError:
+    print("pykeepass is not installed", file=sys.stderr)
+    sys.exit(1)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("command")                          # 'show'
+    parser.add_argument("--show-protected", action="store_true")
+    parser.add_argument("--attributes", "-a", default="Password")
+    parser.add_argument("--no-password", action="store_true")
+    parser.add_argument("--key-file", "-k", default=None)
+    parser.add_argument("--yubikey", default=None)          # unsupported, accepted silently
+    parser.add_argument("database")
+    parser.add_argument("entry")
+    args = parser.parse_args()
+
+    if args.command != "show":
+        print(f"Unsupported command: {args.command}", file=sys.stderr)
+        sys.exit(1)
+
+    password = None if args.no_password else input("Enter password to unlock database: ")
+
+    try:
+        kp = PyKeePass(args.database, password=password, keyfile=args.key_file)
+    except CredentialsError:
+        print("Error: invalid credentials for KeePass database", file=sys.stderr)
+        sys.exit(1)
+    except FileNotFoundError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    # Search by title; support group/title path (e.g. "Group/Entry")
+    parts = args.entry.rsplit("/", 1)
+    if len(parts) == 2:
+        entries = kp.find_entries(title=parts[1], group=kp.find_groups(name=parts[0], first=True), first=True)
+    else:
+        entries = kp.find_entries(title=args.entry, first=True)
+
+    if entries is None:
+        print(f"Error: entry '{args.entry}' not found in database", file=sys.stderr)
+        sys.exit(1)
+
+    attr = args.attributes
+    value = None
+
+    if attr == "Password":
+        value = entries.password
+    elif attr == "UserName":
+        value = entries.username
+    elif attr == "URL":
+        value = entries.url
+    elif attr == "Notes":
+        value = entries.notes
+    elif attr == "Title":
+        value = entries.title
+    else:
+        # Custom attribute
+        value = entries.custom_properties.get(attr)
+
+    if value is None:
+        print(f"Error: attribute '{attr}' not found on entry '{args.entry}'", file=sys.stderr)
+        sys.exit(1)
+
+    print(value)
+
+
+if __name__ == "__main__":
+    main()
+SHIM
+
+chmod +x /usr/local/bin/keepassxc-cli
+echo "[init-keepassxc-cli] Done. keepassxc-cli shim is ready."


### PR DESCRIPTION
Closes https://github.com/borgmatic-collective/docker-borgmatic/issues/450
Recreation of https://github.com/borgmatic-collective/docker-borgmatic/pull/489

## Summary

Adds optional KeePassXC credential support via a lightweight Python shim, for use with borgmatic's \`{credential keepassxc ...}\` syntax introduced in borgmatic 1.9.11.

Alpine's only KeePassXC package pulls in the full Qt6 GUI stack (~150 MB). Rather than baking that into the image for all users, this ships an opt-in init script that users who need KeePass support can mount at startup. Users who don't need it simply don't mount it and get no extra image weight.

### Files added

- \`data/borgscripts/init-keepassxc-cli.sh\` — custom init script that installs [\`pykeepass\`](https://github.com/libkeepass/pykeepass) (~2 MB, pure Python, no system deps) and writes a \`/usr/local/bin/keepassxc-cli\` shim at container startup
- \`data/borgscripts/KEEPASSXC-CLI.md\` — setup guide covering volume mounts, borgmatic config, key file usage, unattended backup setup, and security notes

### How it works

The shim implements the exact CLI interface borgmatic calls:

```
keepassxc-cli show --show-protected --attributes Password [--no-password] [--key-file ...] database.kdbx entry
```

Because it installs to \`/usr/local/bin/keepassxc-cli\`, borgmatic needs no changes — it calls the same path and gets identical stdout output. Supported attributes: \`Password\`, \`UserName\`, \`URL\`, \`Notes\`, \`Title\`, and custom attributes. Group-path style entry names (\`Group/Entry\`) are supported.

### Unattended backups — key file approach

The real \`keepassxc-cli\` prompts for the database master password interactively, which breaks scheduled (cron) backups. The shim supports the same \`--no-password\` + \`--key-file\` flags as the real binary, allowing the database to be unlocked from a key file alone with no prompt:

```yaml
# docker-compose.yml
volumes:
  - ./data/borgscripts/init-keepassxc-cli.sh:/custom-cont-init.d/init-keepassxc-cli.sh:ro
  - /path/to/passwords.kdbx:/etc/borgmatic/passwords.kdbx:ro
  - /path/to/passwords.keyx:/run/secrets/keepass.keyx:ro
```

```yaml
# borgmatic config
keepassxc:
  database: /etc/borgmatic/passwords.kdbx
  ask_for_password: false    # skip interactive prompt — required for cron
  key_file: /run/secrets/keepass.keyx

encryption_passphrase: "{credential keepassxc /etc/borgmatic/passwords.kdbx MyEntry}"
```

The key file should be stored outside the backup source directory and mounted read-only so it is not included in its own backup.

### Secret Service integration — not supported

borgmatic also supports a \`{credential keepassxc secret-service <key>}\` syntax that retrieves credentials via the D-Bus Secret Service API (the mechanism desktop apps use to talk to a running KeePassXC or GNOME Keyring instance).

This does **not** work in a headless Docker container. The Secret Service API requires a running D-Bus session bus and a Secret Service provider (KeePassXC GUI or \`gnome-keyring-daemon\`) — neither of which exist in a container, and providing them would pull in the full Qt6/GTK desktop stack this shim exists to avoid. This is documented clearly in \`KEEPASSXC-CLI.md\`.

For unattended Docker backups, the key file approach above is the correct solution.

### Security notes

- \`pykeepass\` reads the KeePass 4 (\`.kdbx\`) format entirely in-process — the database is never sent anywhere
- The shim prints the requested attribute to stdout exactly as the real \`keepassxc-cli\` does; borgmatic captures it in memory and never writes it to disk
- \`pykeepass\` is installed at container startup rather than baked into the image, so it is covered by normal image rebuild/update cycles

## Test plan

- [ ] Mount \`init-keepassxc-cli.sh\` and confirm startup log shows \`[init-keepassxc-cli] Done. keepassxc-cli shim is ready.\`
- [ ] \`docker exec borgmatic keepassxc-cli show --show-protected --attributes Password --no-password --key-file /run/secrets/keepass.keyx /etc/borgmatic/passwords.kdbx MyEntry\` returns the correct value
- [ ] \`docker exec borgmatic keepassxc-cli show --show-protected --attributes UserName --no-password --key-file /run/secrets/keepass.keyx /etc/borgmatic/passwords.kdbx MyEntry\` returns the correct username
- [ ] \`borgmatic config validate\` passes with a \`{credential keepassxc ...}\` reference in config
- [ ] Container without the script mounted starts cleanly with no errors or warnings
- [ ] Cron-scheduled backup completes without prompting for a password when \`ask_for_password: false\` and \`key_file\` are configured